### PR TITLE
Cleanup, support for specifying one or more file/wildcard following the bitrate, and support for spaces in filenames/paths

### DIFF
--- a/mp4towebm
+++ b/mp4towebm
@@ -1,23 +1,28 @@
 #!/usr/bin/env bash
 
-FILE_EXT=".webm"
+NEW_EXT=".webm"
 
 [[ ! $(type -P ffmpeg) ]] && echo 'Error: The ffmpeg executable wasn not found in $PATH' && exit 1
 
 function convert_mp4(){
-    if [ $(grep -e "\.mp4" <<< "$1") ]; then
-        ffmpeg -i "$1" -c:v libvpx -crf 4 -q:v 10 -b:v $1 -c:a libvorbis "${1/\.mp4}${FILE_EXT}"
-    else
-        echo "${1} doesn't appear to be an mp4"
-    fi
+    OLD_EXT=$(sed 's|^.*\.||' <<< "$1")
+    ffmpeg -i "$1" -c:v libvpx -crf 4 -q:v 10 -b:v "$BITRATE" -c:a libvorbis "${1/\.${OLD_EXT}}${NEW_EXT}"
 }
 
 if [ -n "$1" ]; then
+    BITRATE="$1"
+    shift
+else
+    echo "Error: the desired bitrate of the resulting video must be passed as the first argument"
+    exit 1
+fi
+
+if [ -n "$1" ]; then
     for video in "$@"; do
-        if [ -f "$video" ]; then
+        if [[ -f "$video" ]]; then
             convert_mp4 "$video"
         else
-            echo "Error: no video file(s) matching '${1}'"
+            echo "Error: no video file(s) matching '$video'"
         fi
     done
 else


### PR DESCRIPTION
Running with only the **bitrate** as an argument will behave the same as before, except now files that have filenames containing spaces will work too.

You can now also specify a list of files or wildcards to convert, which will be processed instead of `*.mp4`, ie:
- `mp4towebm 8M file1.mp4 file2.mp4 file3.mpg` (we're assuming `file3.mpg` is an incorrectly named **mp4**)
- `mp4towebm 8M new_*.mp4 to_process*.mp4`
- `find . -type f -iname "*.mp4" -exec mp4towebm 8M '{}' \;`

Cheers!
